### PR TITLE
Run `CommandMap` with context class loader

### DIFF
--- a/src/main/java/io/jenkins/plugins/javax/activation/CommandMapInitializer.java
+++ b/src/main/java/io/jenkins/plugins/javax/activation/CommandMapInitializer.java
@@ -1,0 +1,25 @@
+package io.jenkins.plugins.javax.activation;
+
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import javax.activation.CommandMap;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public class CommandMapInitializer {
+
+    @Initializer(after = InitMilestone.PLUGINS_PREPARED, before = InitMilestone.PLUGINS_STARTED)
+    public static synchronized void init() {
+        Thread t = Thread.currentThread();
+        ClassLoader orig = t.getContextClassLoader();
+        t.setContextClassLoader(CommandMapInitializer.class.getClassLoader());
+        try {
+            // Getting the default command map fetches a per-thread-context-class-loader default.
+            // Setting the default command map removes the per-thread-context-class-loader command map.
+            CommandMap.setDefaultCommandMap(new DelegatingCommandMap(CommandMap.getDefaultCommandMap()));
+        } finally {
+            t.setContextClassLoader(orig);
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/javax/activation/DelegatingCommandMap.java
+++ b/src/main/java/io/jenkins/plugins/javax/activation/DelegatingCommandMap.java
@@ -1,0 +1,76 @@
+package io.jenkins.plugins.javax.activation;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.activation.CommandInfo;
+import javax.activation.CommandMap;
+import javax.activation.DataContentHandler;
+import javax.activation.DataSource;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public class DelegatingCommandMap extends CommandMap {
+    private final CommandMap delegate;
+
+    public DelegatingCommandMap(@NonNull CommandMap delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    private static final <T> T runWithContextClassLoader(Supplier<T> supplier) {
+        Thread t = Thread.currentThread();
+        ClassLoader orig = t.getContextClassLoader();
+        t.setContextClassLoader(DelegatingCommandMap.class.getClassLoader());
+        try {
+            return supplier.get();
+        } finally {
+            t.setContextClassLoader(orig);
+        }
+    }
+
+    @Override
+    public CommandInfo[] getPreferredCommands(String mimeType) {
+        return runWithContextClassLoader(() -> delegate.getPreferredCommands(mimeType));
+    }
+
+    @Override
+    public CommandInfo[] getPreferredCommands(String mimeType, DataSource ds) {
+        return runWithContextClassLoader(() -> delegate.getPreferredCommands(mimeType, ds));
+    }
+
+    @Override
+    public CommandInfo[] getAllCommands(String mimeType) {
+        return runWithContextClassLoader(() -> delegate.getAllCommands(mimeType));
+    }
+
+    @Override
+    public CommandInfo[] getAllCommands(String mimeType, DataSource ds) {
+        return runWithContextClassLoader(() -> delegate.getAllCommands(mimeType, ds));
+    }
+
+    @Override
+    public CommandInfo getCommand(String mimeType, String cmdName) {
+        return runWithContextClassLoader(() -> delegate.getCommand(mimeType, cmdName));
+    }
+
+    @Override
+    public CommandInfo getCommand(String mimeType, String cmdName, DataSource ds) {
+        return runWithContextClassLoader(() -> delegate.getCommand(mimeType, cmdName, ds));
+    }
+
+    @Override
+    public DataContentHandler createDataContentHandler(String mimeType) {
+        return runWithContextClassLoader(() -> delegate.createDataContentHandler(mimeType));
+    }
+
+    @Override
+    public DataContentHandler createDataContentHandler(String mimeType, DataSource ds) {
+        return runWithContextClassLoader(() -> delegate.createDataContentHandler(mimeType, ds));
+    }
+
+    @Override
+    public String[] getMimeTypes() {
+        return runWithContextClassLoader(() -> delegate.getMimeTypes());
+    }
+}


### PR DESCRIPTION
Fixes errors like this when using `CommandMap` with a context class loader that doesn't contain JavaMail classes:

```
DEBUG SMTP: IOException while sending, closing, THROW: 
javax.activation.UnsupportedDataTypeException: no object DCH for MIME type multipart/mixed; 
	boundary="----=_Part_5_726582541.1641663022150"
	at javax.activation.ObjectDataContentHandler.writeTo(DataHandler.java:909)
	at javax.activation.DataHandler.writeTo(DataHandler.java:330)
	at javax.mail.internet.MimeBodyPart.writeTo(MimeBodyPart.java:1694)
	at javax.mail.internet.MimeMessage.writeTo(MimeMessage.java:1913)
	at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1315)
	at hudson.plugins.emailext.ExtendedEmailPublisher.sendMail(ExtendedEmailPublisher.java:524)
	at hudson.plugins.emailext.ExtendedEmailPublisher._perform(ExtendedEmailPublisher.java:444)
	at hudson.plugins.emailext.ExtendedEmailPublisher.perform(ExtendedEmailPublisher.java:354)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:814)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:763)
	at hudson.model.Build$BuildExecution.cleanUp(Build.java:189)
	at hudson.model.Run.execute(Run.java:1943)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:442)
```